### PR TITLE
fix(deps): resuelve DoS en js-yaml transitivo (GHSA-h67p-54hq-rp68)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -839,9 +839,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9399,7 +9399,7 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.15.0",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -9419,9 +9419,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
     "prettier": "^2.5.1",
     "supertest": "^7.2.2"
   },
+  "overrides": {
+    "@istanbuljs/load-nyc-config": {
+      "js-yaml": "^3.15.0"
+    }
+  },
   "jest": {
     "testEnvironment": "node",
     "globalSetup": "./tests/setup.js",


### PR DESCRIPTION
## Fix de la alerta Dependabot #37 (js-yaml, moderate, dev-only)

### Vulnerabilidad
- **js-yaml < 3.15.0** — DoS de complejidad cuadrática en el manejo de merge keys vía aliases repetidos (GHSA-h67p-54hq-rp68).
- Llegaba de forma **transitiva y dev-only**: `jest` → `babel-plugin-istanbul` → `@istanbuljs/load-nyc-config` → `js-yaml@3.14.2`.
- Las otras instancias de js-yaml (eslint, swagger-jsdoc) ya usaban 4.2.0 (seguro).

### Fix
`overrides` targeted que fuerza `js-yaml@^3.15.0` solo en la rama de `@istanbuljs/load-nyc-config`, sin tocar las instancias 4.x ni subir majors de Jest.

### Verificación
- ✅ `npm audit`: **0 vulnerabilidades** (antes: 1 moderate)
- ✅ `npm ls js-yaml`: la instancia vulnerable ahora es 3.15.0
- ✅ `npm run test:ci`: **73/73 tests passing**